### PR TITLE
Merge 48-node-serialization into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,9 +639,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake3"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -742,9 +742,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "calloop"
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1507,12 +1507,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2001,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2490,7 +2490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -2565,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2627,9 +2627,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "liberum_cli"
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -3123,7 +3123,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -3216,11 +3216,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -3941,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.10"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -4448,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -4722,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5124,9 +5123,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5135,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5146,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5167,9 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5385,9 +5384,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5396,9 +5395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -5411,21 +5410,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5433,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5446,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wayland-backend"
@@ -5561,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5581,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5f07fb9bc8de2ddfe6b24a71a75430673fd679e568c48b52716cef1cfae923"
+checksum = "ea9fe1ebb156110ff855242c1101df158b822487e4957b0556d9ffce9db0f535"
 dependencies = [
  "block2",
  "core-foundation 0.10.0",

--- a/liberum_core/Cargo.toml
+++ b/liberum_core/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1"
 tokio = {version = "1.40", features = ["full"] }
 libp2p = { version = "0.54", features = [ "tokio", "ping", "macros", "quic", "kad", "request-response", "cbor"] }
-tracing = { version = "0.1"}
+tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 daemonize = "0.5.0"
 tokio-util = {version="0.7", features=["codec", "io"]}

--- a/liberum_core/src/connection/mod.rs
+++ b/liberum_core/src/connection/mod.rs
@@ -10,7 +10,7 @@ use crate::node::store::NodeStore;
 use crate::node::DialPeer;
 use crate::node::DownloadFile;
 use crate::node::GetProviders;
-use crate::node::Node;
+use crate::node::NodeSnapshot;
 use crate::node::ProvideFile;
 use crate::node::PublishFile;
 use anyhow::Result;
@@ -156,15 +156,16 @@ async fn handle_new_node(
         Some(seed) => liberum_core::node_keypair_from_seed(&seed),
         None => Keypair::generate_ed25519(),
     };
-    let node = Node::builder()
-        .name(name)
-        .keypair(keypair)
-        .build()
-        .map_err(|e| DaemonError::Other(e.to_string()))?;
+    let node_snapshot = NodeSnapshot {
+        name,
+        keypair,
+        bootstrap_nodes: vec![],
+        external_addresses: vec![],
+    };
 
     let resp = context
         .node_manager
-        .ask(node::manager::CreateNode { node })
+        .ask(node::manager::CreateNode { node_snapshot })
         .send()
         .await;
     match resp {

--- a/liberum_core/src/connection/mod.rs
+++ b/liberum_core/src/connection/mod.rs
@@ -156,12 +156,12 @@ async fn handle_new_node(
         Some(seed) => liberum_core::node_keypair_from_seed(&seed),
         None => Keypair::generate_ed25519(),
     };
-    let node_snapshot = NodeSnapshot {
-        name,
-        keypair,
-        bootstrap_nodes: vec![],
-        external_addresses: vec![],
-    };
+    let node_snapshot = NodeSnapshot::builder()
+        .name(name)
+        .keypair(keypair)
+        .build_snapshot()
+        // This can't fail
+        .unwrap();
 
     let resp = context
         .node_manager

--- a/liberum_core/src/node/manager.rs
+++ b/liberum_core/src/node/manager.rs
@@ -1,6 +1,6 @@
 use super::{
     store::{ListNodes, NodeStore, NodeStoreError, StoreNode},
-    GetSnapshot, Node,
+    GetSnapshot, Node, NodeSnapshot,
 };
 use crate::node::store::LoadNode;
 use anyhow::anyhow;
@@ -58,9 +58,12 @@ impl NodeManager {
     }
 
     #[message]
-    pub async fn create_node(&mut self, node: Node) -> Result<(), NodeManagerError> {
+    pub async fn create_node(
+        &mut self,
+        node_snapshot: NodeSnapshot,
+    ) -> Result<(), NodeManagerError> {
         self.store
-            .ask(StoreNode { node })
+            .ask(StoreNode { node_snapshot })
             .send()
             .await
             .map_err(|e| NodeManagerError::OtherError(e.into()))?;
@@ -205,7 +208,9 @@ impl NodeManager {
             .map_err(|e| NodeManagerError::OtherError(e.into()))?;
 
         self.store
-            .ask(StoreNode { node: snapshot })
+            .ask(StoreNode {
+                node_snapshot: snapshot,
+            })
             .send()
             .await
             .map_err(|e| NodeManagerError::OtherError(e.into()))?;

--- a/liberum_core/src/node/mod.rs
+++ b/liberum_core/src/node/mod.rs
@@ -295,9 +295,6 @@ impl Node {
 }
 
 impl Node {
-    const CONFIG_FILE_NAME: &'static str = "config.json";
-    const KEY_FILE_NAME: &'static str = "keypair";
-
     pub fn builder() -> NodeBuilder {
         NodeBuilder::default()
     }

--- a/liberum_core/src/node/mod.rs
+++ b/liberum_core/src/node/mod.rs
@@ -291,64 +291,6 @@ impl Node {
         NodeBuilder::default()
     }
 
-    //async fn load(node_dir_path: &Path) -> Result<Node> {
-    //    if !node_dir_path.is_dir() {
-    //        error!(
-    //            dir_path = node_dir_path.display().to_string(),
-    //            "node dir path not a directory"
-    //        );
-    //        bail!("node_dir_path is not a directory");
-    //    }
-
-    //    let config_path = node_dir_path.join(Node::CONFIG_FILE_NAME);
-    //    let config = NodeConfig::load(&config_path).await?;
-    //    let key_path = node_dir_path.join(Node::KEY_FILE_NAME);
-    //    let key_bytes = tokio::fs::read(key_path)
-    //        .await
-    //        .inspect_err(|e| error!(err = e.to_string(), "could not read node keypair bytes"))?;
-    //    let keypair = Keypair::from_protobuf_encoding(&key_bytes)?;
-    //    let node_name = node_dir_path
-    //        .file_name()
-    //        .ok_or(anyhow!(
-    //            "incorrect node dir path, it should not end with .."
-    //        ))?
-    //        .to_str()
-    //        .ok_or(anyhow!("node dir path is not valid utf-8 string"))
-    //        .inspect_err(|e| error!(err = e.to_string(), "could not resolve node name"))?
-    //        .to_string();
-    //    let node = Node::builder()
-    //        .name(node_name)
-    //        .config(config)
-    //        .keypair(keypair)
-    //        .build()
-    //        .inspect_err(|e| error!(err = e.to_string(), "error while building node"))?;
-
-    //    Ok(node)
-    //}
-
-    //async fn save(&self, node_dir_path: &Path) -> Result<()> {
-    //    if !node_dir_path.is_dir() {
-    //        error!("node dir path is not a directory");
-    //        bail!("node_dir_path is not a directory");
-    //    }
-
-    //    let config: NodeConfig = self.into();
-    //    let config_path = node_dir_path.join(Node::CONFIG_FILE_NAME);
-    //    let key_bytes = self
-    //        .keypair
-    //        .to_protobuf_encoding()
-    //        .inspect_err(|e| error!(err = e.to_string(), "could not convert keypair to bytes"))?;
-    //    let key_path = node_dir_path.join(Node::KEY_FILE_NAME);
-
-    //    tokio::fs::write(key_path, key_bytes)
-    //        .await
-    //        .inspect_err(|e| error!(err = e.to_string(), "could not write node keypair"))?;
-
-    //    config.save(&config_path).await?;
-
-    //    Ok(())
-    //}
-
     async fn start_swarm(&mut self) -> Result<()> {
         let node_ref = self
             .self_actor_ref
@@ -369,29 +311,6 @@ impl fmt::Debug for Node {
             .finish()
     }
 }
-
-impl Into<NodeConfig> for &Node {
-    fn into(self) -> NodeConfig {
-        NodeConfig::new(
-            self.bootstrap_nodes.clone(),
-            self.external_addresses.clone(),
-        )
-    }
-}
-
-//impl Clone for Node {
-//    fn clone(&self) -> Self {
-//        Self {
-//            name: self.name.clone(),
-//            keypair: self.keypair.clone(),
-//            bootstrap_nodes: self.bootstrap_nodes.clone(),
-//            manager_ref: None,
-//            external_addresses: self.external_addresses.clone(),
-//            self_actor_ref: None,
-//            swarm_sender: None,
-//        }
-//    }
-//}
 
 pub struct GetSnapshot;
 
@@ -462,5 +381,14 @@ impl From<&Node> for NodeSnapshot {
             bootstrap_nodes: value.bootstrap_nodes.clone(),
             external_addresses: value.external_addresses.clone(),
         }
+    }
+}
+
+impl Into<NodeConfig> for &NodeSnapshot {
+    fn into(self) -> NodeConfig {
+        NodeConfig::new(
+            self.bootstrap_nodes.clone(),
+            self.external_addresses.clone(),
+        )
     }
 }

--- a/liberum_core/src/node/mod.rs
+++ b/liberum_core/src/node/mod.rs
@@ -377,6 +377,16 @@ impl NodeBuilder {
         self
     }
 
+    pub fn bootstrap_nodes(mut self, bootstrap_nodes: Vec<BootstrapNode>) -> Self {
+        self.bootstrap_nodes = bootstrap_nodes;
+        self
+    }
+
+    pub fn external_addresses(mut self, external_addresses: Vec<Multiaddr>) -> Self {
+        self.external_addresses = external_addresses;
+        self
+    }
+
     pub fn from_snapshot(mut self, snapshot: &NodeSnapshot) -> Self {
         self.name = Some(snapshot.name.clone());
         self.keypair = Some(snapshot.keypair.clone());
@@ -386,10 +396,9 @@ impl NodeBuilder {
     }
 
     pub fn build(self) -> Result<Node> {
-        let keypair = self.keypair.ok_or(anyhow!("keypair is required"))?;
         let node = Node {
             name: self.name.ok_or(anyhow!("node name is required"))?,
-            keypair: keypair,
+            keypair: self.keypair.ok_or(anyhow!("keypair is required"))?,
             bootstrap_nodes: self.bootstrap_nodes,
             manager_ref: self
                 .manager_ref
@@ -398,7 +407,19 @@ impl NodeBuilder {
             self_actor_ref: self.self_actor_ref,
             swarm_sender: self.swarm_sender,
         };
+
         Ok(node)
+    }
+
+    pub fn build_snapshot(self) -> Result<NodeSnapshot> {
+        let snapshot = NodeSnapshot {
+            name: self.name.ok_or(anyhow!("node name is required"))?,
+            keypair: self.keypair.ok_or(anyhow!("keypair is required"))?,
+            bootstrap_nodes: self.bootstrap_nodes,
+            external_addresses: self.external_addresses,
+        };
+
+        Ok(snapshot)
     }
 }
 
@@ -407,6 +428,12 @@ pub struct NodeSnapshot {
     pub keypair: Keypair,
     pub bootstrap_nodes: Vec<BootstrapNode>,
     pub external_addresses: Vec<Multiaddr>,
+}
+
+impl NodeSnapshot {
+    pub fn builder() -> NodeBuilder {
+        NodeBuilder::default()
+    }
 }
 
 impl From<&Node> for NodeSnapshot {

--- a/liberum_core/src/node/store.rs
+++ b/liberum_core/src/node/store.rs
@@ -1,4 +1,3 @@
-use crate::node::Node;
 use anyhow::{anyhow, Context, Result};
 use kameo::{messages, Actor};
 use liberum_core::node_config::NodeConfig;
@@ -61,11 +60,11 @@ impl NodeStore {
             return Err(anyhow!("node_dir_path is not a directory").into());
         }
 
-        let config_path = node_dir_path.join(Node::CONFIG_FILE_NAME);
+        let config_path = node_dir_path.join(Self::NODE_CONFIG_FILE_NAME);
         let config = NodeConfig::load(&config_path)
             .await
             .context("failed to load node config")?;
-        let key_path = node_dir_path.join(Node::KEY_FILE_NAME);
+        let key_path = node_dir_path.join(Self::NODE_KEY_FILE_NAME);
         let key_bytes = tokio::fs::read(key_path)
             .await
             .inspect_err(|e| error!(err = e.to_string(), "could not read node keypair bytes"))
@@ -101,13 +100,13 @@ impl NodeStore {
         }
 
         let config: NodeConfig = (&node_snapshot).into();
-        let config_path = node_dir_path.join(Node::CONFIG_FILE_NAME);
+        let config_path = node_dir_path.join(Self::NODE_CONFIG_FILE_NAME);
         let key_bytes = node_snapshot
             .keypair
             .to_protobuf_encoding()
             .inspect_err(|e| error!(err = e.to_string(), "could not convert keypair to bytes"))
             .context("could not convert keypair to bytes")?;
-        let key_path = node_dir_path.join(Node::KEY_FILE_NAME);
+        let key_path = node_dir_path.join(Self::NODE_KEY_FILE_NAME);
 
         tokio::fs::write(key_path, key_bytes)
             .await
@@ -176,6 +175,8 @@ impl NodeStore {
 
 impl NodeStore {
     const DEFAULT_NODES_DIRECTORY_NAME: &'static str = ".liberum-neto";
+    const NODE_CONFIG_FILE_NAME: &'static str = "config.json";
+    const NODE_KEY_FILE_NAME: &'static str = "keypair";
 
     pub async fn new(store_dir_path: &Path) -> Result<Self> {
         NodeStore::ensure_store_dir_path(store_dir_path)
@@ -241,7 +242,7 @@ impl NodeStore {
     fn resolve_node_config_path(&self, name: &str) -> PathBuf {
         let node_dir_path = self.resolve_node_dir_path(name);
 
-        node_dir_path.join(Node::CONFIG_FILE_NAME)
+        node_dir_path.join(Self::NODE_CONFIG_FILE_NAME)
     }
 
     async fn ensure_store_dir_path(path: &Path) -> Result<()> {

--- a/liberum_core/src/node/store.rs
+++ b/liberum_core/src/node/store.rs
@@ -284,17 +284,19 @@ mod tests {
             .await
             .unwrap();
         let node_store = kameo::spawn(node_store);
-        let new_node = Node::builder()
-            .name("test_node".to_string())
-            .keypair(Keypair::generate_ed25519())
-            .build()
-            .unwrap();
-        let node_snapshot = NodeSnapshot::from(&new_node);
+        let node_snapshot = NodeSnapshot {
+            name: "test_node".to_string(),
+            keypair: Keypair::generate_ed25519(),
+            bootstrap_nodes: vec![],
+            external_addresses: vec![],
+        };
+
         node_store
             .ask(StoreNode { node_snapshot })
             .send()
             .await
             .unwrap();
+
         let got_node_name = node_store
             .ask(LoadNode {
                 name: "test_node".to_string(),
@@ -303,6 +305,7 @@ mod tests {
             .await
             .unwrap()
             .name;
+
         assert_eq!(got_node_name, "test_node");
     }
 

--- a/liberum_core/src/node/store.rs
+++ b/liberum_core/src/node/store.rs
@@ -71,12 +71,14 @@ impl NodeStore {
             .context("could not read node keypair bytes")?;
         let keypair = Keypair::from_protobuf_encoding(&key_bytes)
             .context("could not read keypair from protobuf encoded bytes")?;
-        let node_snapshot = NodeSnapshot {
-            name,
-            keypair,
-            bootstrap_nodes: config.bootstrap_nodes,
-            external_addresses: config.external_addresses,
-        };
+        let node_snapshot = NodeSnapshot::builder()
+            .name(name)
+            .keypair(keypair)
+            .bootstrap_nodes(config.bootstrap_nodes)
+            .external_addresses(config.external_addresses)
+            .build_snapshot()
+            // This can't fail
+            .unwrap();
 
         Ok(node_snapshot)
     }
@@ -274,12 +276,11 @@ mod tests {
             .await
             .unwrap();
         let node_store = kameo::spawn(node_store);
-        let node_snapshot = NodeSnapshot {
-            name: "test_node".to_string(),
-            keypair: Keypair::generate_ed25519(),
-            bootstrap_nodes: vec![],
-            external_addresses: vec![],
-        };
+        let node_snapshot = NodeSnapshot::builder()
+            .name("test_node".to_string())
+            .keypair(Keypair::generate_ed25519())
+            .build_snapshot()
+            .unwrap();
 
         node_store
             .ask(StoreNode { node_snapshot })

--- a/liberum_core/src/swarm_runner/behaviour/file_share.rs
+++ b/liberum_core/src/swarm_runner/behaviour/file_share.rs
@@ -54,7 +54,7 @@ impl SwarmContext {
                 } => self.handle_file_share_response(request_id, response),
             },
             e => debug!(
-                node = self.node.name,
+                node = self.node_snapshot.name,
                 "Received request_response event! {e:?}"
             ),
         }
@@ -90,7 +90,7 @@ impl SwarmContext {
         if response.data.is_none() {
             debug!(
                 requested = liberum_core::file_id_to_str(id.clone()),
-                node = self.node.name,
+                node = self.node_snapshot.name,
                 "Requested file not found"
             );
         }
@@ -103,14 +103,14 @@ impl SwarmContext {
             .send_response(response_channel, response)
             .inspect_err(|e| {
                 debug!(
-                    node = self.node.name,
+                    node = self.node_snapshot.name,
                     "Request_response request response_channel closed: {:?}", e
                 );
             });
         if let Err(e) = r {
             debug!(
                 requested = liberum_core::file_id_to_str(id),
-                node = self.node.name,
+                node = self.node_snapshot.name,
                 "Failed to send request_response response: {:?}",
                 e
             );
@@ -123,13 +123,13 @@ impl SwarmContext {
         request_id: OutboundRequestId,
         response: FileResponse,
     ) {
-        debug!(node = self.node.name, "received request_response response!");
+        debug!(node = self.node_snapshot.name, "received request_response response!");
         // Get the response data and send it to the pending download
         let result: Result<Vec<u8>>;
         if let Some(data) = response.data {
             result = Ok(data);
         } else {
-            debug!(node = self.node.name, "requested File not found");
+            debug!(node = self.node_snapshot.name, "requested File not found");
             result = Err(anyhow!("File not found"));
         }
 

--- a/liberum_core/src/swarm_runner/behaviour/file_share.rs
+++ b/liberum_core/src/swarm_runner/behaviour/file_share.rs
@@ -123,7 +123,10 @@ impl SwarmContext {
         request_id: OutboundRequestId,
         response: FileResponse,
     ) {
-        debug!(node = self.node_snapshot.name, "received request_response response!");
+        debug!(
+            node = self.node_snapshot.name,
+            "received request_response response!"
+        );
         // Get the response data and send it to the pending download
         let result: Result<Vec<u8>>;
         if let Some(data) = response.data {

--- a/liberum_core/src/swarm_runner/messages.rs
+++ b/liberum_core/src/swarm_runner/messages.rs
@@ -126,7 +126,7 @@ impl SwarmContext {
             } => {
                 if self.behaviour.providing.contains_key(&id) {
                     info!(
-                        node = self.node.name,
+                        node = self.node_snapshot.name,
                         id = format!("{id:?}"),
                         "File is already being provided"
                     );


### PR DESCRIPTION
This MR separates saving logic from the Node moving it to NodeStore. Node implements Into<NodeSnapshot> and such snapshots may be passed to NodeStore for saving. Whenever Node needs to be loaded from NodeStore user should firstly get a node snapshot by sending LoadNode message and then using NodeSnapshot in the NodeBuilder (from_snapshot method).