### PR TITLE
Merge 60-node-details-cli into main

### DIFF
--- a/liberum_core/src/lib/lib.rs
+++ b/liberum_core/src/lib/lib.rs
@@ -44,6 +44,9 @@ pub enum DaemonRequest {
         node_name: String,
     },
     ListNodes,
+    GetNodeDetails {
+        node_name: String,
+    },
     ProvideFile {
         node_name: String,
         path: PathBuf,
@@ -85,6 +88,7 @@ pub enum DaemonResponse {
     NodeConfigUpdated,
     NodeStopped,
     NodeList(Vec<NodeInfo>),
+    NodeDetails(NodeInfo),
     FileProvided { id: String },
     Providers { ids: Vec<String> },
     FileDownloaded { data: PlainFileObject }, // TODO ideally the data should not be a Vec<u8> but some kind of a stream to save it to disk instead of downloading the whole file in memory

--- a/liberum_core/src/vault/mod.rs
+++ b/liberum_core/src/vault/mod.rs
@@ -568,6 +568,7 @@ mod tests {
 
         file.write_all(&[65; 4096]).await.unwrap();
         file.write_all(&[66; 2048]).await.unwrap();
+        file.flush().await.unwrap();
 
         let mut fragments = Vault::fragment(&file_path).await.unwrap();
 


### PR DESCRIPTION
This PR adds new Daemon request-response: GetNodeDetails and adds new CLI command get-node-details, which allows to get information about a single Node (more efficient if we know what Node to get). The output is the same as in node list currently.