### PR TITLE
[#62] Print and return error if command failed in handle_response

### DIFF
--- a/liberum_cli/src/main.rs
+++ b/liberum_cli/src/main.rs
@@ -714,7 +714,13 @@ async fn handle_response(
     response_receiver: &mut tokio::sync::mpsc::Receiver<Result<DaemonResponse, DaemonError>>,
 ) -> Result<()> {
     match response_receiver.recv().await {
-        Some(r) => info!(response = format!("{r:?}"), "Daemon responds"),
+        Some(r) => {
+            info!(response = format!("{r:?}"), "Daemon responds");
+
+            if let Err(e) = r {
+                return Err(e.into());
+            }
+        }
         None => {
             error!("Failed to receive response");
         }


### PR DESCRIPTION
The fix to this problem was simple, just check and return error from handle_response function.